### PR TITLE
fix typo

### DIFF
--- a/MNIST/main.py
+++ b/MNIST/main.py
@@ -64,7 +64,7 @@ def test(evaluate=False):
         pred = output.data.max(1, keepdim=True)[1]
         correct += pred.eq(target.data.view_as(pred)).cpu().sum()
     
-    acc = 100. * correct / len(test_loader.dataset)
+    acc = 100. * float(correct) / len(test_loader.dataset)
     if ((args.prune == 'node') and (not args.retrain)) or (acc > best_acc):
         best_acc = acc
         if not evaluate:
@@ -73,7 +73,7 @@ def test(evaluate=False):
     test_loss /= len(test_loader.dataset)
     print('\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.2f}%)'.format(
         test_loss * args.batch_size, correct, len(test_loader.dataset),
-        100. * correct / len(test_loader.dataset)))
+        100. * float(correct) / len(test_loader.dataset)))
     print('Best Accuracy: {:.2f}%\n'.format(best_acc))
     return
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here is the results for node pruning:
   <tr>
     <td>LeNet-5</td>
     <td>MNIST</td>
-    <td>1->9/20(conv)->18/50(conv)->165/500(ip)->10(ip)</td>
+    <td>1->9/20(conv)->18/50(conv)->65/500(ip)->10(ip)</td>
     <td>99.34%</td>
     <td>99.34%</td>
   </tr>

--- a/util/util.py
+++ b/util/util.py
@@ -94,7 +94,7 @@ class SIMD_Prune_Op():
                     shape = tmp_pruned.shape
                     tmp_pruned = tmp_pruned.pow(2.0).mean(2, keepdim=True).pow(0.5)\
                             .expand(tmp_pruned.shape).lt(threshold)
-                    tmp_pruned[:, -1] = False
+                    tmp_pruned[:, -1] = 0
                     tmp_pruned = tmp_pruned.view(tmp_pruned.shape[0], -1)
                     tmp_pruned = tmp_pruned[:, 0:m.weight.data.shape[1]]
                     model.weights_pruned.append(tmp_pruned)
@@ -108,7 +108,7 @@ class SIMD_Prune_Op():
                     shape = tmp_pruned.shape
                     tmp_pruned = tmp_pruned.pow(2.0).mean(2, keepdim=True).pow(0.5)\
                             .expand(tmp_pruned.shape).lt(threshold)
-                    tmp_pruned[:, -1] = False
+                    tmp_pruned[:, -1] = 0
                     tmp_pruned = tmp_pruned.view(original_size[0], -1)
                     tmp_pruned = tmp_pruned[:, 0:m.weight.data[0].nelement()]
                     tmp_pruned = tmp_pruned.view(original_size)


### PR DESCRIPTION
1. fix a calculation mistake of remaining nodes in README file.

2. fix the accuracy computation of MNIST node pruning models.