### PR TITLE
Alternative Import for Pickle (Python3 Compatible)

### DIFF
--- a/CIFAR_10/data.py
+++ b/CIFAR_10/data.py
@@ -1,9 +1,12 @@
 import os
 import torch
-import cPickle as pickle
 import numpy
 import torchvision.transforms as transforms
-
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+    
 class dataset():
     def __init__(self, root=None, train=True):
         self.root = root


### PR DESCRIPTION
There is no module cPickle in Python3

https://blog.csdn.net/zcf1784266476/article/details/70655192
https://forums.fast.ai/t/no-module-named-cpickle/3171
https://stackoverflow.com/questions/49579282/cant-find-module-cpickle-using-python-3-5-and-anaconda